### PR TITLE
Log levels and typos in comments fixed

### DIFF
--- a/analytics/accounts.go
+++ b/analytics/accounts.go
@@ -8,7 +8,8 @@ import (
 	ga "google.golang.org/api/analytics/v3"
 )
 
-// Each account is stored as a Profile struct, with an individual profile ID, // property and account. Accounts can have multiple properties, and each
+// Each account is stored as a Profile struct, with an individual profile ID,
+// property and account. Accounts can have multiple properties, and each
 // property can have multiple profiles.
 // https://github.com/google/google-api-go-client/blob/master/analytics/v3/analytics-gen.go
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,8 @@ type Config struct {
 	LogLevel string
 }
 
-// NewConfig creates an instance of the Config struct with the default values. // Values can be overridden after initialized.
+// NewConfig creates an instance of the Config struct with the default values.
+// Values can be overridden after initialized.
 func NewConfig() Config {
 	c := Config{}
 

--- a/log/log.go
+++ b/log/log.go
@@ -29,7 +29,12 @@ func InitLog(module string) {
 
 	// Filter the log based off of the configured log level
 	l := log.AddModuleLevel(formatter)
-	l.SetLevel(log.GetLevel(config.LogLevel), "")
+
+	// Load the log level from the configuration
+	level, _ := log.LogLevel(config.LogLevel)
+
+	// Set the log level to the configured log level
+	l.SetLevel(level, "")
 
 	// Tell the log instance to use the leveled logs
 	log.SetBackend(l)

--- a/main.go
+++ b/main.go
@@ -18,9 +18,6 @@ func main() {
 	// TODO: Actually do something here to establish a database connection
 	config.DatabaseConnection.DatabaseHost = "localhost"
 
-	print(config.LogLevel)
-	print(config.AnalyticsAPIKey)
-
 	// Start logger
 	log.InitLog("SummitAPI")
 

--- a/main.go
+++ b/main.go
@@ -26,10 +26,12 @@ func main() {
 
 	log.Logger.Info("Application log initialized")
 
-	// Run the ConnectAnalytics function that autheticates with Google using oAuth and preps the analytics.Service for use
+	// Run the ConnectAnalytics function that autheticates with Google using
+	// oAuth and preps the analytics.Service for use
 	analytics.ConnectAnalytics()
 
-	// Get a list of the account, property and profile IDs from Google analytics for the email address that's been autheticated
+	// Get a list of the account, property and profile IDs from Google
+	// analytics for the email address that's been autheticated
 	analytics.GetID()
 
 	// Output the grabbed profiles


### PR DESCRIPTION
The logging levels were returning improper values, so grabbing the configurable log level as a string and using that instead addresses the issue. 